### PR TITLE
Implement JWT admin auth & QR code improvements

### DIFF
--- a/app/admin/(dashboard)/layout.tsx
+++ b/app/admin/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { verifyAdminCookie } from "@/app/api/admin-auth/route";
 
 export const metadata = {
   robots: "noindex, nofollow",
@@ -11,9 +12,9 @@ export default async function AdminDashboardLayout({
   children: React.ReactNode;
 }) {
   const cookieStore = await cookies();
-  const adminCookie = cookieStore.get("cv_admin")?.value;
+  const token = cookieStore.get("cv_admin")?.value;
 
-  if (!adminCookie || adminCookie !== process.env.ADMIN_PASSWORD) {
+  if (!(await verifyAdminCookie(token))) {
     redirect("/admin/login");
   }
 

--- a/app/api/admin-auth/route.ts
+++ b/app/api/admin-auth/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
+import { SignJWT, jwtVerify } from "jose";
 
 const ADMIN_COOKIE = "cv_admin";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+function getSecret() {
+  const secret = process.env.ADMIN_JWT_SECRET;
+  if (!secret) throw new Error("ADMIN_JWT_SECRET is not set");
+  return new TextEncoder().encode(secret);
+}
 
 export async function POST(request: NextRequest) {
   const { username, password } = await request.json();
@@ -14,13 +22,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
   }
 
+  const token = await new SignJWT({ sub: "admin" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("7d")
+    .sign(getSecret());
+
   const response = NextResponse.json({ ok: true });
-  response.cookies.set(ADMIN_COOKIE, process.env.ADMIN_PASSWORD, {
+  response.cookies.set(ADMIN_COOKIE, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     path: "/",
-    maxAge: 60 * 60 * 24 * 7, // 7 days
+    maxAge: COOKIE_MAX_AGE,
   });
 
   return response;
@@ -30,4 +44,14 @@ export async function DELETE() {
   const response = NextResponse.json({ ok: true });
   response.cookies.delete(ADMIN_COOKIE);
   return response;
+}
+
+export async function verifyAdminCookie(token: string | undefined): Promise<boolean> {
+  if (!token) return false;
+  try {
+    await jwtVerify(token, getSecret());
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sanity/vision": "^5.13.0",
         "@supabase/supabase-js": "^2.98.0",
         "framer-motion": "^12.35.0",
+        "jose": "^6.2.0",
         "next": "16.1.6",
         "next-sanity": "^12.1.0",
         "qrcode": "^1.5.4",
@@ -13532,6 +13533,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
+      "integrity": "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@sanity/vision": "^5.13.0",
     "@supabase/supabase-js": "^2.98.0",
     "framer-motion": "^12.35.0",
+    "jose": "^6.2.0",
     "next": "16.1.6",
     "next-sanity": "^12.1.0",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## Summary

- **JWT authentication**: Replace raw-password cookie with a signed HS256 JWT using `jose`. The cookie no longer contains the admin password — the layout now verifies the JWT signature against `ADMIN_JWT_SECRET`
- **QR code refactor**: Extract shared `QRModal` component from `TableManager` into `components/admin/QRModal.tsx`; add QR button to `OrderFeed` header when a specific table is selected
- **Stat overflow fix**: Fix text overflow in order stat cards on narrow screens

## New env variable required
```
# Generate with: openssl rand -base64 32
ADMIN_JWT_SECRET=
```
Add this to Vercel environment variables before deploying. Existing admin sessions will be invalidated on first deploy (users will be redirected to login once).

## Test plan
- [ ] Login with correct credentials → redirected to dashboard, cookie set
- [ ] Login with wrong credentials → error shown, no cookie
- [ ] Logout → cookie cleared, redirected to login
- [ ] Refresh dashboard with valid session → stays logged in
- [ ] Manually delete cookie → redirected to login
- [ ] QR modal opens from both TableManager and OrderFeed header

🤖 Generated with [Claude Code](https://claude.com/claude-code)