### PR TITLE
Standardize language switcher across all pages

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -4,6 +4,7 @@ import { useState, FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { adminDict } from "@/lib/i18n/adminDict";
 import { useAdminLang } from "@/hooks/useAdminLang";
+import LangSwitcher from "@/components/LangSwitcher";
 
 export default function AdminLoginPage() {
   const router = useRouter();
@@ -50,20 +51,8 @@ export default function AdminLoginPage() {
 
       <div className="w-full max-w-sm relative">
         {/* Lang toggle */}
-        <div className="flex justify-end mb-6 gap-1">
-          {(["en", "ja"] as const).map((l) => (
-            <button
-              key={l}
-              onClick={() => setLang(l)}
-              className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                lang === l
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/60"
-              }`}
-            >
-              {l === "en" ? "EN" : "JP"}
-            </button>
-          ))}
+        <div className="flex justify-end mb-6">
+          <LangSwitcher lang={lang} setLang={setLang} />
         </div>
 
         {/* Logo / Brand */}

--- a/components/LangSwitcher.tsx
+++ b/components/LangSwitcher.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { LOCALE_LABELS, SUPPORTED_LOCALES } from "@/lib/i18n/config";
+import type { Lang } from "@/lib/i18n/config";
+
+interface LangSwitcherProps {
+  lang: Lang;
+  setLang: (l: Lang) => void;
+}
+
+export default function LangSwitcher({ lang, setLang }: LangSwitcherProps) {
+  return (
+    <div className="flex items-center gap-1">
+      {SUPPORTED_LOCALES.map((l, i) => (
+        <span key={l} className="flex items-center">
+          {i > 0 && <span className="text-brand-purple mx-1">|</span>}
+          <button
+            onClick={() => setLang(l)}
+            className={`text-sm font-semibold tracking-wider transition-colors ${
+              lang === l
+                ? "text-brand-pink"
+                : "text-white/60 hover:text-white"
+            }`}
+          >
+            {LOCALE_LABELS[l]}
+          </button>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/components/admin/CredentialsManager.tsx
+++ b/components/admin/CredentialsManager.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { adminDict } from "@/lib/i18n/adminDict";
 import { useAdminLang } from "@/hooks/useAdminLang";
+import LangSwitcher from "@/components/LangSwitcher";
 
 export default function CredentialsManager({ logoUrl, username }: { logoUrl?: string; username?: string }) {
   const { lang, setLang } = useAdminLang();
@@ -142,20 +143,8 @@ export default function CredentialsManager({ logoUrl, username }: { logoUrl?: st
 
       {/* Lang toggle + Logout */}
       <div className="px-3 py-4 border-t border-white/5 shrink-0 flex flex-col gap-1">
-        <div className="flex gap-1 px-1 mb-1">
-          {(["en", "ja"] as const).map((l) => (
-            <button
-              key={l}
-              onClick={() => setLang(l)}
-              className={`flex-1 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                lang === l
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/60"
-              }`}
-            >
-              {l === "en" ? "EN" : "JP"}
-            </button>
-          ))}
+        <div className="px-3 mb-1">
+          <LangSwitcher lang={lang} setLang={setLang} />
         </div>
         <button onClick={handleLogout}
           className="flex items-center gap-2.5 w-full px-3 py-2 rounded-xl text-sm font-medium text-white/40 hover:text-white hover:bg-white/5 transition-all">

--- a/components/admin/OrderFeed.tsx
+++ b/components/admin/OrderFeed.tsx
@@ -8,6 +8,7 @@ import type { Table } from "@/lib/supabase/types";
 import { adminDict } from "@/lib/i18n/adminDict";
 import { useAdminLang } from "@/hooks/useAdminLang";
 import { QRModal, type QRTable } from "@/components/admin/QRModal";
+import LangSwitcher from "@/components/LangSwitcher";
 
 interface OrderFeedProps {
   initialOrders: Order[];
@@ -284,20 +285,8 @@ export default function OrderFeed({ initialOrders, tables, logoUrl, username }: 
 
       {/* Lang toggle + Logout */}
       <div className="px-3 py-4 border-t border-white/5 shrink-0 flex flex-col gap-1">
-        <div className="flex gap-1 px-1 mb-1">
-          {(["en", "ja"] as const).map((l) => (
-            <button
-              key={l}
-              onClick={() => setLang(l)}
-              className={`flex-1 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                lang === l
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/60"
-              }`}
-            >
-              {l === "en" ? "EN" : "JP"}
-            </button>
-          ))}
+        <div className="px-3 mb-1">
+          <LangSwitcher lang={lang} setLang={setLang} />
         </div>
         <button onClick={handleLogout}
           className="flex items-center gap-2.5 w-full px-3 py-2 rounded-xl text-sm font-medium text-white/40 hover:text-white hover:bg-white/5 transition-all">

--- a/components/admin/TableManager.tsx
+++ b/components/admin/TableManager.tsx
@@ -7,6 +7,7 @@ import type { Table } from "@/lib/supabase/types";
 import { adminDict } from "@/lib/i18n/adminDict";
 import { useAdminLang } from "@/hooks/useAdminLang";
 import { QRModal } from "@/components/admin/QRModal";
+import LangSwitcher from "@/components/LangSwitcher";
 
 export default function TableManager({ initialTables, logoUrl, username }: { initialTables: Table[]; logoUrl?: string; username?: string }) {
   const { lang, setLang } = useAdminLang();
@@ -138,20 +139,8 @@ export default function TableManager({ initialTables, logoUrl, username }: { ini
 
       {/* Lang toggle + Logout */}
       <div className="px-3 py-4 border-t border-white/5 shrink-0 flex flex-col gap-1">
-        <div className="flex gap-1 px-1 mb-1">
-          {(["en", "ja"] as const).map((l) => (
-            <button
-              key={l}
-              onClick={() => setLang(l)}
-              className={`flex-1 py-1.5 rounded-lg text-xs font-semibold transition-all ${
-                lang === l
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/60"
-              }`}
-            >
-              {l === "en" ? "EN" : "JP"}
-            </button>
-          ))}
+        <div className="px-3 mb-1">
+          <LangSwitcher lang={lang} setLang={setLang} />
         </div>
         <button onClick={handleLogout}
           className="flex items-center gap-2.5 w-full px-3 py-2 rounded-xl text-sm font-medium text-white/40 hover:text-white hover:bg-white/5 transition-all">

--- a/components/order/OrderUI.tsx
+++ b/components/order/OrderUI.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import type { OrderSession } from "@/lib/supabase/types";
 import type { OrderMenuCategory, OrderMenuItem } from "@/lib/types/order";
 import type { CartItem } from "@/lib/supabase/types";
+import LangSwitcher from "@/components/LangSwitcher";
 
 type Lang = "en" | "ja";
 type View = "menu" | "cart" | "confirmation";
@@ -38,9 +39,9 @@ function buildSections(categories: OrderMenuCategory[], lang: Lang): Section[] {
 // ─── Header ───────────────────────────────────────────────────────────────────
 
 function Header({
-  tableName, lang, onLangToggle, cartCount, onCartOpen, view, onBack,
+  tableName, lang, setLang, cartCount, onCartOpen, view, onBack,
 }: {
-  tableName: string; lang: Lang; onLangToggle: () => void;
+  tableName: string; lang: Lang; setLang: (l: Lang) => void;
   cartCount: number; onCartOpen: () => void; view: View; onBack: () => void;
 }) {
   return (
@@ -63,12 +64,7 @@ function Header({
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
-          <button
-            onClick={onLangToggle}
-            className="text-xs font-semibold px-3 py-2 rounded-lg border border-white/10 text-white/50 hover:text-white hover:border-white/30 transition-all"
-          >
-            {lang === "en" ? "日本語" : "English"}
-          </button>
+          <LangSwitcher lang={lang} setLang={setLang} />
           {view === "menu" && (
             <button
               onClick={onCartOpen}
@@ -414,7 +410,7 @@ export default function OrderUI({ session, categories }: OrderUIProps) {
 
       <Header
         tableName={session.tableName} lang={lang}
-        onLangToggle={() => setLang((l) => l === "en" ? "ja" : "en")}
+        setLang={setLang}
         cartCount={cartCount} onCartOpen={() => setView("cart")}
         view={view} onBack={() => setView("menu")}
       />


### PR DESCRIPTION
Replace inline lang toggle buttons in admin and order pages with a shared LangSwitcher component that matches the homepage design (EN | JP with pipe separator, brand-pink active state).