### PR TITLE
Fix order panel shrinking menu on desktop

### DIFF
--- a/components/order/OrderUI.tsx
+++ b/components/order/OrderUI.tsx
@@ -472,14 +472,10 @@ export default function OrderUI({ session, categories, logoUrl }: OrderUIProps) 
         {/* Desktop: floating card, always visible alongside menu */}
         {/* Mobile: full-screen overlay when view === "cart" */}
         <div className={`
-          lg:w-2/5 lg:shrink-0 lg:flex lg:flex-col lg:min-h-0 lg:py-4 lg:pr-4 lg:pl-3
+          lg:w-2/5 lg:flex-none lg:flex lg:flex-col lg:min-h-0 lg:py-4 lg:pr-4 lg:pl-3
           ${view === "menu" ? "hidden lg:flex" : "flex flex-col flex-1 min-h-0"}
         `}>
-          <div className={`flex flex-col flex-1 min-h-0 ${
-            view !== "confirmation"
-              ? "lg:rounded-2xl lg:border lg:border-white/8 lg:bg-white/[0.02] lg:overflow-hidden"
-              : ""
-          }`}>
+          <div className="flex flex-col flex-1 min-h-0 lg:rounded-2xl lg:border lg:border-white/8 lg:bg-white/[0.02] lg:overflow-hidden">
             {view === "confirmation"
               ? <Confirmation lang={lang} onOrderMore={() => setView("menu")} />
               : <CartPanel cart={cart} lang={lang} onRemove={removeFromCart} onAdd={addByKey}


### PR DESCRIPTION
The right panel's conditional class added flex-1 on confirmation view, causing both panels to compete for space equally (50/50) instead of the intended 60/40 split. Replace lg:shrink-0 with lg:flex-none so flex-1 only affects mobile. Also always apply card styling so confirmation renders inside the same card as cart.