### PR TITLE
Add crew role, user management, and order audit trail

### DIFF
--- a/app/admin/(dashboard)/page.tsx
+++ b/app/admin/(dashboard)/page.tsx
@@ -4,13 +4,13 @@ import { supabase } from "@/lib/supabase/client";
 export const metadata: Metadata = { title: "Admin" };
 import { client } from "@/sanity/lib/client";
 import { adminLogoQuery } from "@/sanity/lib/queries";
-import { getUsername } from "@/app/api/admin-auth/route";
+import { getUsername, getRole } from "@/app/api/admin-auth/route";
 import OrderFeed from "@/components/admin/OrderFeed";
 import type { Order } from "@/lib/supabase/types";
 import type { Table } from "@/lib/supabase/types";
 
 export default async function AdminDashboardPage() {
-  const [ordersResult, tablesResult, logoUrl, username] = await Promise.all([
+  const [ordersResult, tablesResult, logoUrl, username, role] = await Promise.all([
     supabase
       .from("orders")
       .select("*, table:tables(id, name), items:order_items(*)")
@@ -22,10 +22,20 @@ export default async function AdminDashboardPage() {
       .order("created_at", { ascending: true }),
     client.fetch<string | null>(adminLogoQuery).catch(() => null),
     getUsername(),
+    getRole(),
   ]);
 
   const orders = (ordersResult.data ?? []) as Order[];
   const tables = (tablesResult.data ?? []) as Pick<Table, "id" | "name" | "secret_key">[];
+  const userRole = (role === "crew" ? "crew" : "admin") as "admin" | "crew";
 
-  return <OrderFeed initialOrders={orders} tables={tables} logoUrl={logoUrl ?? undefined} username={username} />;
+  return (
+    <OrderFeed
+      initialOrders={orders}
+      tables={tables}
+      logoUrl={logoUrl ?? undefined}
+      username={username}
+      role={userRole}
+    />
+  );
 }

--- a/app/admin/(dashboard)/settings/page.tsx
+++ b/app/admin/(dashboard)/settings/page.tsx
@@ -1,15 +1,31 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { client } from "@/sanity/lib/client";
 import { adminLogoQuery } from "@/sanity/lib/queries";
-import { getUsername } from "@/app/api/admin-auth/route";
+import { getUsername, getRole } from "@/app/api/admin-auth/route";
+import { supabase } from "@/lib/supabase/client";
 import CredentialsManager from "@/components/admin/CredentialsManager";
 
 export const metadata: Metadata = { title: "Settings" };
 
 export default async function AdminSettingsPage() {
-  const [logoUrl, username] = await Promise.all([
+  const role = await getRole();
+  if (role !== "admin") redirect("/admin");
+
+  const [logoUrl, username, usersResult] = await Promise.all([
     client.fetch<string | null>(adminLogoQuery).catch(() => null),
     getUsername(),
+    supabase.from("users").select("id, username, role").order("created_at", { ascending: true }),
   ]);
-  return <CredentialsManager logoUrl={logoUrl ?? undefined} username={username} />;
+
+  const initialUsers = (usersResult.data ?? []) as { id: string; username: string; role: string }[];
+
+  return (
+    <CredentialsManager
+      logoUrl={logoUrl ?? undefined}
+      username={username}
+      role="admin"
+      initialUsers={initialUsers}
+    />
+  );
 }

--- a/app/admin/(dashboard)/tables/page.tsx
+++ b/app/admin/(dashboard)/tables/page.tsx
@@ -1,14 +1,18 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { supabase } from "@/lib/supabase/client";
 
 export const metadata: Metadata = { title: "Tables" };
 import { client } from "@/sanity/lib/client";
 import { adminLogoQuery } from "@/sanity/lib/queries";
-import { getUsername } from "@/app/api/admin-auth/route";
+import { getUsername, getRole } from "@/app/api/admin-auth/route";
 import TableManager from "@/components/admin/TableManager";
 import type { Table } from "@/lib/supabase/types";
 
 export default async function AdminTablesPage() {
+  const role = await getRole();
+  if (role !== "admin") redirect("/admin");
+
   const [{ data }, logoUrl, username] = await Promise.all([
     supabase.from("tables").select("*").order("created_at", { ascending: true }),
     client.fetch<string | null>(adminLogoQuery).catch(() => null),
@@ -17,5 +21,5 @@ export default async function AdminTablesPage() {
 
   const tables = (data ?? []) as Table[];
 
-  return <TableManager initialTables={tables} logoUrl={logoUrl ?? undefined} username={username} />;
+  return <TableManager initialTables={tables} logoUrl={logoUrl ?? undefined} username={username} role="admin" />;
 }

--- a/app/api/admin-auth/route.ts
+++ b/app/api/admin-auth/route.ts
@@ -87,3 +87,10 @@ export async function getUsername(): Promise<string | undefined> {
   const payload = await getAdminTokenPayload(token);
   return payload?.username;
 }
+
+export async function getRole(): Promise<string | undefined> {
+  const { cookies } = await import("next/headers");
+  const token = (await cookies()).get("cv_admin")?.value;
+  const payload = await getAdminTokenPayload(token);
+  return payload?.role;
+}

--- a/app/api/admin-auth/verify/route.ts
+++ b/app/api/admin-auth/verify/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { supabase } from "@/lib/supabase/client";
+
+// Verifies that the provided credentials belong to an admin user.
+// Does NOT set a cookie — used by crew members to authorize sensitive actions.
+export async function POST(request: NextRequest) {
+  const { username, password } = await request.json();
+
+  if (!username || !password) {
+    return NextResponse.json({ error: "Username and password are required" }, { status: 400 });
+  }
+
+  const { data: user, error: dbError } = await supabase
+    .from("users")
+    .select("id, password_hash, role")
+    .eq("username", username)
+    .single();
+
+  if (dbError) {
+    console.error("[admin-auth/verify] DB error:", dbError.message);
+    return NextResponse.json({ error: "DB error" }, { status: 500 });
+  }
+
+  if (!user || !(await bcrypt.compare(password, user.password_hash))) {
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+  }
+
+  if (user.role !== "admin") {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { supabase } from "@/lib/supabase/client";
+import { getAdminTokenPayload } from "@/app/api/admin-auth/route";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("cv_admin")?.value;
+  const payload = await getAdminTokenPayload(token);
+
+  if (!payload || payload.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  if (id === payload.sub) {
+    return NextResponse.json({ error: "Cannot delete your own account" }, { status: 400 });
+  }
+
+  const { error } = await supabase.from("users").delete().eq("id", id);
+
+  if (error) {
+    console.error("[admin/users/:id] DB error:", error.message);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { cookies } from "next/headers";
+import { supabase } from "@/lib/supabase/client";
+import { getAdminTokenPayload } from "@/app/api/admin-auth/route";
+
+async function requireAdmin() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("cv_admin")?.value;
+  const payload = await getAdminTokenPayload(token);
+  if (!payload || payload.role !== "admin") return null;
+  return payload;
+}
+
+export async function GET() {
+  const payload = await requireAdmin();
+  if (!payload) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("users")
+    .select("id, username, role")
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    console.error("[admin/users] DB error:", error.message);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ users: data });
+}
+
+export async function POST(request: NextRequest) {
+  const payload = await requireAdmin();
+  if (!payload) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { username, password, role } = await request.json();
+
+  if (!username?.trim() || !password || !role) {
+    return NextResponse.json({ error: "username, password, and role are required" }, { status: 400 });
+  }
+
+  if (role !== "admin" && role !== "crew") {
+    return NextResponse.json({ error: "role must be admin or crew" }, { status: 400 });
+  }
+
+  const password_hash = await bcrypt.hash(password, 12);
+
+  const { data, error } = await supabase
+    .from("users")
+    .insert({ username: username.trim(), password_hash, role })
+    .select("id, username, role")
+    .single();
+
+  if (error) {
+    console.error("[admin/users] DB error:", error.message);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ user: data }, { status: 201 });
+}

--- a/app/api/orders/[id]/route.ts
+++ b/app/api/orders/[id]/route.ts
@@ -1,28 +1,42 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase/client";
 import type { OrderStatus } from "@/lib/supabase/types";
-import { verifyAdminCookie } from "@/app/api/admin-auth/route";
+import { verifyAdminCookie, getAdminTokenPayload } from "@/app/api/admin-auth/route";
 
 // PATCH /api/orders/[id] — update order status (admin only)
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  if (!(await verifyAdminCookie(request.cookies.get("cv_admin")?.value))) {
+  const token = request.cookies.get("cv_admin")?.value;
+  if (!(await verifyAdminCookie(token))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const payload = await getAdminTokenPayload(token);
+  const actingUsername = payload?.username ?? null;
 
   const { id } = await params;
   const body = await request.json();
   const status: OrderStatus = body.status;
+  const authorizedBy: string | null = body.authorized_by ?? null;
 
   if (!["pending", "done", "cancelled"].includes(status)) {
     return NextResponse.json({ error: "Invalid status" }, { status: 400 });
   }
 
+  const updateData: Record<string, unknown> = { status };
+
+  if (status === "done") {
+    updateData.completed_by = actingUsername;
+  } else if (status === "cancelled") {
+    updateData.canceled_by = actingUsername;
+    updateData.authorized_by = authorizedBy ?? actingUsername;
+  }
+
   const { data, error } = await supabase
     .from("orders")
-    .update({ status })
+    .update(updateData)
     .eq("id", id)
     .select()
     .single();

--- a/components/admin/AdminAuthModal.tsx
+++ b/components/admin/AdminAuthModal.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { adminDict } from "@/lib/i18n/adminDict";
+
+interface AdminAuthModalProps {
+  t: typeof adminDict["en"];
+  onConfirm: (adminUsername: string) => void;
+  onClose: () => void;
+}
+
+export function AdminAuthModal({ t, onConfirm, onClose }: AdminAuthModalProps) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [verifying, setVerifying] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setVerifying(true);
+    try {
+      const res = await fetch("/api/admin-auth/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+      if (res.ok) {
+        onConfirm(username);
+      } else {
+        setError(t.invalidAdminCredentials);
+      }
+    } catch {
+      setError(t.invalidAdminCredentials);
+    } finally {
+      setVerifying(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-dark-800 rounded-3xl border border-white/10 w-full max-w-sm p-6 flex flex-col gap-5 shadow-2xl shadow-black/50"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <div className="w-7 h-7 rounded-full bg-red-400/15 border border-red-400/20 flex items-center justify-center shrink-0">
+                <svg className="w-3.5 h-3.5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                </svg>
+              </div>
+              <p className="text-white font-bold text-sm">{t.adminAuthRequired}</p>
+            </div>
+            <p className="text-white/40 text-xs leading-relaxed">{t.adminAuthDesc}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center text-white/40 hover:text-white hover:bg-white/10 transition-all shrink-0"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <input
+            type="text"
+            autoComplete="username"
+            placeholder={t.username}
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+          />
+          <input
+            type="password"
+            autoComplete="current-password"
+            placeholder={t.password}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+          />
+          {error && <p className="text-red-400 text-xs">{error}</p>}
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 py-3 rounded-full bg-white/5 border border-white/10 text-white/60 font-semibold text-sm hover:bg-white/10 hover:text-white transition-all"
+            >
+              {t.cancel}
+            </button>
+            <button
+              type="submit"
+              disabled={verifying || !username || !password}
+              className="flex-1 py-3 rounded-full bg-red-500/80 hover:bg-red-500 text-white font-semibold text-sm transition-all disabled:opacity-40"
+            >
+              {verifying ? t.verifying : t.confirmCancel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -12,6 +12,7 @@ interface AdminSidebarProps {
   lang: Lang;
   setLang: (l: Lang) => void;
   activePage: "orders" | "tables" | "settings";
+  role?: "admin" | "crew";
   // Orders page — table list
   tables?: { id: string; name: string }[];
   activeTableId?: string;
@@ -25,6 +26,7 @@ export default function AdminSidebar({
   lang,
   setLang,
   activePage,
+  role = "admin",
   tables,
   activeTableId,
   onTableSelect,
@@ -115,51 +117,53 @@ export default function AdminSidebar({
           </div>
         </div>
 
-        <div>
-          <p className="text-white/20 text-[10px] font-semibold uppercase tracking-widest px-2 mb-2">
-            {t.management}
-          </p>
-          <div className="flex flex-col gap-0.5">
-            {activePage === "tables" ? (
-              <button className={navItem(true)}>
-                <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
-                </svg>
-                {t.tableManagement}
-              </button>
-            ) : (
-              <Link
-                href="/admin/tables"
-                onClick={onMobileClose}
-                className="flex items-center gap-2.5 px-3 py-2 rounded-xl text-sm font-medium text-white/50 hover:text-white hover:bg-white/5 transition-all"
-              >
-                <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
-                </svg>
-                {t.tableManagement}
-              </Link>
-            )}
-            {activePage === "settings" ? (
-              <button className={navItem(true)}>
-                <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
-                </svg>
-                {t.userManagement}
-              </button>
-            ) : (
-              <Link
-                href="/admin/settings"
-                onClick={onMobileClose}
-                className="flex items-center gap-2.5 px-3 py-2 rounded-xl text-sm font-medium text-white/50 hover:text-white hover:bg-white/5 transition-all"
-              >
-                <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
-                </svg>
-                {t.userManagement}
-              </Link>
-            )}
+        {role === "admin" && (
+          <div>
+            <p className="text-white/20 text-[10px] font-semibold uppercase tracking-widest px-2 mb-2">
+              {t.management}
+            </p>
+            <div className="flex flex-col gap-0.5">
+              {activePage === "tables" ? (
+                <button className={navItem(true)}>
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+                  </svg>
+                  {t.tableManagement}
+                </button>
+              ) : (
+                <Link
+                  href="/admin/tables"
+                  onClick={onMobileClose}
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-xl text-sm font-medium text-white/50 hover:text-white hover:bg-white/5 transition-all"
+                >
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+                  </svg>
+                  {t.tableManagement}
+                </Link>
+              )}
+              {activePage === "settings" ? (
+                <button className={navItem(true)}>
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+                  </svg>
+                  {t.userManagement}
+                </button>
+              ) : (
+                <Link
+                  href="/admin/settings"
+                  onClick={onMobileClose}
+                  className="flex items-center gap-2.5 px-3 py-2 rounded-xl text-sm font-medium text-white/50 hover:text-white hover:bg-white/5 transition-all"
+                >
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+                  </svg>
+                  {t.userManagement}
+                </Link>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </nav>
 
       {/* Lang toggle + Logout */}

--- a/components/admin/CredentialsManager.tsx
+++ b/components/admin/CredentialsManager.tsx
@@ -4,8 +4,21 @@ import { useState } from "react";
 import { adminDict } from "@/lib/i18n/adminDict";
 import { useAdminLang } from "@/hooks/useAdminLang";
 import AdminSidebar from "@/components/admin/AdminSidebar";
+import UserManager from "@/components/admin/UserManager";
 
-export default function CredentialsManager({ logoUrl, username }: { logoUrl?: string; username?: string }) {
+interface User { id: string; username: string; role: string }
+
+export default function CredentialsManager({
+  logoUrl,
+  username,
+  role = "admin",
+  initialUsers = [],
+}: {
+  logoUrl?: string;
+  username?: string;
+  role?: "admin" | "crew";
+  initialUsers?: User[];
+}) {
   const { lang, setLang } = useAdminLang();
   const t = adminDict[lang];
 
@@ -86,6 +99,7 @@ export default function CredentialsManager({ logoUrl, username }: { logoUrl?: st
       lang={lang}
       setLang={setLang}
       activePage="settings"
+      role={role}
       onMobileClose={() => setMobileOpen(false)}
     />
   );
@@ -131,98 +145,114 @@ export default function CredentialsManager({ logoUrl, username }: { logoUrl?: st
           </button>
         </div>
 
-        <div className="flex-1 max-w-xl px-5 sm:px-8 py-6 sm:py-8 flex flex-col gap-8">
+        <div className="flex-1 px-5 sm:px-8 py-6 sm:py-8 flex flex-col gap-6">
           {/* Page header */}
           <div>
             <h1 className="text-white font-bold text-xl leading-tight">{t.accountSettings}</h1>
           </div>
 
-          {/* Change Username */}
-          <div className="rounded-2xl border border-white/8 bg-white/[0.02] p-5 sm:p-6">
-            <h2 className="text-white font-semibold mb-4">{t.changeUsername}</h2>
-            <form onSubmit={handleUpdateUsername} className="flex flex-col gap-3">
-              <div className="flex flex-col gap-1.5">
-                <label className="text-white/40 text-xs font-medium">{t.newUsername}</label>
-                <input
-                  type="text"
-                  value={newUsername}
-                  onChange={(e) => setNewUsername(e.target.value)}
-                  autoComplete="username"
-                  className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <label className="text-white/40 text-xs font-medium">{t.currentPassword}</label>
-                <input
-                  type="password"
-                  value={currentPasswordForUsername}
-                  onChange={(e) => setCurrentPasswordForUsername(e.target.value)}
-                  autoComplete="current-password"
-                  className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
-                />
-              </div>
-              {usernameStatus && (
-                <p className={`text-xs ${usernameStatus.ok ? "text-emerald-400" : "text-red-400"}`}>
-                  {usernameStatus.msg}
-                </p>
-              )}
-              <button
-                type="submit"
-                disabled={savingUsername || !newUsername.trim() || !currentPasswordForUsername}
-                className="self-start px-5 py-2.5 rounded-xl bg-gradient-to-r from-brand-pink to-brand-purple text-white font-semibold text-sm hover:opacity-90 transition-all disabled:opacity-40 shadow-lg shadow-brand-pink/15"
-              >
-                {savingUsername ? t.saving : t.saveChanges}
-              </button>
-            </form>
-          </div>
+          {/* Two-column grid */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 
-          {/* Change Password */}
-          <div className="rounded-2xl border border-white/8 bg-white/[0.02] p-5 sm:p-6">
-            <h2 className="text-white font-semibold mb-4">{t.changePassword}</h2>
-            <form onSubmit={handleUpdatePassword} className="flex flex-col gap-3">
-              <div className="flex flex-col gap-1.5">
-                <label className="text-white/40 text-xs font-medium">{t.currentPassword}</label>
-                <input
-                  type="password"
-                  value={currentPassword}
-                  onChange={(e) => setCurrentPassword(e.target.value)}
-                  autoComplete="current-password"
-                  className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
-                />
+            {/* Left: Account Management */}
+            <div className="flex flex-col gap-4">
+              <p className="text-white/30 text-[11px] font-semibold uppercase tracking-widest">{t.accountManagement}</p>
+
+              {/* Change Username */}
+              <div className="rounded-2xl border border-white/8 bg-white/[0.02] p-5 sm:p-6">
+                <h2 className="text-white font-semibold mb-4">{t.changeUsername}</h2>
+                <form onSubmit={handleUpdateUsername} className="flex flex-col gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-white/40 text-xs font-medium">{t.newUsername}</label>
+                    <input
+                      type="text"
+                      value={newUsername}
+                      onChange={(e) => setNewUsername(e.target.value)}
+                      autoComplete="username"
+                      className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-white/40 text-xs font-medium">{t.currentPassword}</label>
+                    <input
+                      type="password"
+                      value={currentPasswordForUsername}
+                      onChange={(e) => setCurrentPasswordForUsername(e.target.value)}
+                      autoComplete="current-password"
+                      className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+                    />
+                  </div>
+                  {usernameStatus && (
+                    <p className={`text-xs ${usernameStatus.ok ? "text-emerald-400" : "text-red-400"}`}>
+                      {usernameStatus.msg}
+                    </p>
+                  )}
+                  <button
+                    type="submit"
+                    disabled={savingUsername || !newUsername.trim() || !currentPasswordForUsername}
+                    className="self-start px-5 py-2.5 rounded-xl bg-gradient-to-r from-brand-pink to-brand-purple text-white font-semibold text-sm hover:opacity-90 transition-all disabled:opacity-40 shadow-lg shadow-brand-pink/15"
+                  >
+                    {savingUsername ? t.saving : t.saveChanges}
+                  </button>
+                </form>
               </div>
-              <div className="flex flex-col gap-1.5">
-                <label className="text-white/40 text-xs font-medium">{t.newPassword}</label>
-                <input
-                  type="password"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  autoComplete="new-password"
-                  className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
-                />
+
+              {/* Change Password */}
+              <div className="rounded-2xl border border-white/8 bg-white/[0.02] p-5 sm:p-6">
+                <h2 className="text-white font-semibold mb-4">{t.changePassword}</h2>
+                <form onSubmit={handleUpdatePassword} className="flex flex-col gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-white/40 text-xs font-medium">{t.currentPassword}</label>
+                    <input
+                      type="password"
+                      value={currentPassword}
+                      onChange={(e) => setCurrentPassword(e.target.value)}
+                      autoComplete="current-password"
+                      className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-white/40 text-xs font-medium">{t.newPassword}</label>
+                    <input
+                      type="password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      autoComplete="new-password"
+                      className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-white/40 text-xs font-medium">{t.confirmPassword}</label>
+                    <input
+                      type="password"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      autoComplete="new-password"
+                      className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+                    />
+                  </div>
+                  {passwordStatus && (
+                    <p className={`text-xs ${passwordStatus.ok ? "text-emerald-400" : "text-red-400"}`}>
+                      {passwordStatus.msg}
+                    </p>
+                  )}
+                  <button
+                    type="submit"
+                    disabled={savingPassword || !currentPassword || !newPassword || !confirmPassword}
+                    className="self-start px-5 py-2.5 rounded-xl bg-gradient-to-r from-brand-pink to-brand-purple text-white font-semibold text-sm hover:opacity-90 transition-all disabled:opacity-40 shadow-lg shadow-brand-pink/15"
+                  >
+                    {savingPassword ? t.saving : t.saveChanges}
+                  </button>
+                </form>
               </div>
-              <div className="flex flex-col gap-1.5">
-                <label className="text-white/40 text-xs font-medium">{t.confirmPassword}</label>
-                <input
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  autoComplete="new-password"
-                  className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
-                />
-              </div>
-              {passwordStatus && (
-                <p className={`text-xs ${passwordStatus.ok ? "text-emerald-400" : "text-red-400"}`}>
-                  {passwordStatus.msg}
-                </p>
-              )}
-              <button
-                type="submit"
-                disabled={savingPassword || !currentPassword || !newPassword || !confirmPassword}
-                className="self-start px-5 py-2.5 rounded-xl bg-gradient-to-r from-brand-pink to-brand-purple text-white font-semibold text-sm hover:opacity-90 transition-all disabled:opacity-40 shadow-lg shadow-brand-pink/15"
-              >
-                {savingPassword ? t.saving : t.saveChanges}
-              </button>
-            </form>
+            </div>
+
+            {/* Right: User Management */}
+            <div className="flex flex-col gap-4">
+              <p className="text-white/30 text-[11px] font-semibold uppercase tracking-widest">{t.userManagement}</p>
+              <UserManager initialUsers={initialUsers} lang={lang} currentUsername={username} />
+            </div>
+
           </div>
         </div>
       </div>

--- a/components/admin/OrderFeed.tsx
+++ b/components/admin/OrderFeed.tsx
@@ -6,6 +6,7 @@ import type { Table } from "@/lib/supabase/types";
 import { adminDict } from "@/lib/i18n/adminDict";
 import { useAdminLang } from "@/hooks/useAdminLang";
 import { QRModal, type QRTable } from "@/components/admin/QRModal";
+import { AdminAuthModal } from "@/components/admin/AdminAuthModal";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 
 interface OrderFeedProps {
@@ -13,14 +14,17 @@ interface OrderFeedProps {
   tables: Pick<Table, "id" | "name" | "secret_key">[];
   logoUrl?: string;
   username?: string;
+  role: "admin" | "crew";
 }
 
-function OrderCard({ order, onUpdate, isUpdating, t, lang }: {
+function OrderCard({ order, onUpdate, onCancelRequest, isUpdating, t, lang, role }: {
   order: Order;
   onUpdate: (id: string, status: "done" | "cancelled") => void;
+  onCancelRequest: (id: string) => void;
   isUpdating: boolean;
   t: typeof adminDict["en"];
   lang: "en" | "ja";
+  role: "admin" | "crew";
 }) {
   const isPending = order.status === "pending";
   const isCancelled = order.status === "cancelled";
@@ -89,7 +93,7 @@ function OrderCard({ order, onUpdate, isUpdating, t, lang }: {
         </div>
         {isPending && (
           <div className="flex items-center gap-2">
-            <button onClick={() => onUpdate(order.id, "cancelled")} disabled={isUpdating}
+            <button onClick={() => role === "crew" ? onCancelRequest(order.id) : onUpdate(order.id, "cancelled")} disabled={isUpdating}
               className="flex items-center gap-2 px-4 py-2 rounded-full bg-white/5 text-white/30 text-sm font-semibold hover:text-red-400 hover:bg-red-400/10 transition-all disabled:opacity-40 border border-white/10 hover:border-red-400/20">
               {isUpdating ? (
                 <span className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
@@ -114,7 +118,7 @@ function OrderCard({ order, onUpdate, isUpdating, t, lang }: {
   );
 }
 
-export default function OrderFeed({ initialOrders, tables, logoUrl, username }: OrderFeedProps) {
+export default function OrderFeed({ initialOrders, tables, logoUrl, username, role }: OrderFeedProps) {
   const { lang, setLang } = useAdminLang();
   const t = adminDict[lang];
 
@@ -127,6 +131,7 @@ export default function OrderFeed({ initialOrders, tables, logoUrl, username }: 
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [qrTable, setQrTable] = useState<QRTable | null>(null);
+  const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchOrders = useCallback(async () => {
@@ -166,13 +171,15 @@ export default function OrderFeed({ initialOrders, tables, logoUrl, username }: 
     setIsRefreshing(false);
   }
 
-  async function handleUpdate(id: string, status: "done" | "cancelled") {
+  async function handleUpdate(id: string, status: "done" | "cancelled", authorizedBy?: string) {
     setUpdatingId(id);
     try {
+      const body: Record<string, unknown> = { status };
+      if (status === "cancelled") body.authorized_by = authorizedBy ?? username;
       const res = await fetch(`/api/orders/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status }),
+        body: JSON.stringify(body),
       });
       if (res.ok) setOrders((prev) => prev.map((o) => o.id === id ? { ...o, status } : o));
     } finally { setUpdatingId(null); }
@@ -212,6 +219,7 @@ export default function OrderFeed({ initialOrders, tables, logoUrl, username }: 
       lang={lang}
       setLang={setLang}
       activePage="orders"
+      role={role}
       tables={tables}
       activeTableId={activeTableId}
       onTableSelect={(id) => setActiveTableId(id)}
@@ -391,7 +399,7 @@ export default function OrderFeed({ initialOrders, tables, logoUrl, username }: 
             <div className="columns-1 sm:columns-2 xl:columns-3 gap-4 space-y-4">
               {filtered.map((order) => (
                 <div key={order.id} className="break-inside-avoid">
-                  <OrderCard order={order} onUpdate={handleUpdate} isUpdating={updatingId === order.id} t={t} lang={lang} />
+                  <OrderCard order={order} onUpdate={handleUpdate} onCancelRequest={setPendingCancelId} isUpdating={updatingId === order.id} t={t} lang={lang} role={role} />
                 </div>
               ))}
             </div>
@@ -401,6 +409,16 @@ export default function OrderFeed({ initialOrders, tables, logoUrl, username }: 
       </div>
 
       {qrTable && <QRModal table={qrTable} onClose={() => setQrTable(null)} t={t} />}
+      {pendingCancelId && (
+        <AdminAuthModal
+          t={t}
+          onConfirm={(adminUsername) => {
+            handleUpdate(pendingCancelId, "cancelled", adminUsername);
+            setPendingCancelId(null);
+          }}
+          onClose={() => setPendingCancelId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/components/admin/TableManager.tsx
+++ b/components/admin/TableManager.tsx
@@ -7,7 +7,7 @@ import { useAdminLang } from "@/hooks/useAdminLang";
 import { QRModal } from "@/components/admin/QRModal";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 
-export default function TableManager({ initialTables, logoUrl, username }: { initialTables: Table[]; logoUrl?: string; username?: string }) {
+export default function TableManager({ initialTables, logoUrl, username, role = "admin" }: { initialTables: Table[]; logoUrl?: string; username?: string; role?: "admin" | "crew" }) {
   const { lang, setLang } = useAdminLang();
   const t = adminDict[lang];
 
@@ -81,6 +81,7 @@ export default function TableManager({ initialTables, logoUrl, username }: { ini
       lang={lang}
       setLang={setLang}
       activePage="tables"
+      role={role}
       onMobileClose={() => setMobileOpen(false)}
     />
   );

--- a/components/admin/UserManager.tsx
+++ b/components/admin/UserManager.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+import { adminDict } from "@/lib/i18n/adminDict";
+import type { Lang } from "@/lib/i18n/config";
+
+interface User {
+  id: string;
+  username: string;
+  role: string;
+}
+
+interface UserManagerProps {
+  initialUsers: User[];
+  lang: Lang;
+  currentUsername?: string;
+}
+
+export default function UserManager({ initialUsers, lang, currentUsername }: UserManagerProps) {
+  const t = adminDict[lang];
+  const [users, setUsers] = useState<User[]>(initialUsers);
+
+  // Create form
+  const [newUsername, setNewUsername] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newRole, setNewRole] = useState("crew");
+  const [creating, setCreating] = useState(false);
+  const [createStatus, setCreateStatus] = useState<{ ok: boolean; msg: string } | null>(null);
+
+  // Delete
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newUsername.trim() || !newPassword) return;
+    setCreating(true);
+    setCreateStatus(null);
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: newUsername.trim(), password: newPassword, role: newRole }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setUsers((prev) => [...prev, data.user]);
+        setNewUsername("");
+        setNewPassword("");
+        setNewRole("crew");
+        setCreateStatus({ ok: true, msg: t.userCreated });
+      } else {
+        setCreateStatus({ ok: false, msg: t.failedToCreateUser });
+      }
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeletingId(id);
+    setConfirmDeleteId(null);
+    try {
+      const res = await fetch(`/api/admin/users/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        setUsers((prev) => prev.filter((u) => u.id !== id));
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-white/8 bg-white/[0.02] p-5 sm:p-6 flex flex-col gap-5">
+      <div>
+        <h2 className="text-white font-semibold">{t.manageUsers}</h2>
+        <p className="text-white/40 text-xs mt-0.5">{t.manageUsersDesc}</p>
+      </div>
+
+      {/* User list */}
+      <div className="flex flex-col gap-2">
+        {users.length === 0 ? (
+          <p className="text-white/30 text-sm">{t.noUsers}</p>
+        ) : (
+          users.map((user) => (
+            <div
+              key={user.id}
+              className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-white/[0.03] border border-white/5"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="w-7 h-7 rounded-full bg-white/8 border border-white/10 flex items-center justify-center shrink-0">
+                  <svg className="w-3.5 h-3.5 text-white/40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+                  </svg>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-white text-sm font-medium truncate">{user.username}</p>
+                  <span className={`text-[10px] font-semibold uppercase tracking-wider ${
+                    user.role === "admin" ? "text-brand-pink/70" : "text-white/30"
+                  }`}>
+                    {user.role === "admin" ? t.adminRole : t.crewRole}
+                  </span>
+                </div>
+              </div>
+              {user.username !== currentUsername && (
+                confirmDeleteId === user.id ? (
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button
+                      onClick={() => setConfirmDeleteId(null)}
+                      className="px-3 py-1.5 rounded-lg text-xs font-semibold text-white/40 hover:text-white transition-all"
+                    >
+                      {t.cancel}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(user.id)}
+                      disabled={deletingId === user.id}
+                      className="px-3 py-1.5 rounded-lg bg-red-500/15 border border-red-500/20 text-red-400 text-xs font-semibold hover:bg-red-500/25 transition-all disabled:opacity-40"
+                    >
+                      {t.delete}
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setConfirmDeleteId(user.id)}
+                    disabled={!!deletingId}
+                    className="w-7 h-7 rounded-lg flex items-center justify-center text-white/20 hover:text-red-400 hover:bg-red-400/10 transition-all disabled:opacity-40 shrink-0"
+                  >
+                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+                    </svg>
+                  </button>
+                )
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Create user form */}
+      <div className="border-t border-white/5 pt-5">
+        <form onSubmit={handleCreate} className="flex flex-col gap-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-white/40 text-xs font-medium">{t.username}</label>
+              <input
+                type="text"
+                value={newUsername}
+                onChange={(e) => setNewUsername(e.target.value)}
+                autoComplete="off"
+                className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-white/40 text-xs font-medium">{t.newPassword}</label>
+              <input
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                autoComplete="new-password"
+                className="px-4 py-3 rounded-xl bg-white/5 border border-white/10 text-white text-sm placeholder-white/25 focus:outline-none focus:border-brand-pink/50 transition-colors"
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-white/40 text-xs font-medium">{t.roleLabel}</label>
+            <div className="relative">
+              <select
+                value={newRole}
+                onChange={(e) => setNewRole(e.target.value)}
+                className="w-full px-4 py-3 pr-10 rounded-xl bg-white/5 border border-white/10 text-white text-sm focus:outline-none focus:border-brand-pink/50 transition-colors appearance-none cursor-pointer"
+              >
+                <option value="crew" className="bg-dark-800 text-white">{t.crewRole}</option>
+                <option value="admin" className="bg-dark-800 text-white">{t.adminRole}</option>
+              </select>
+              <svg className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/30" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </div>
+          {createStatus && (
+            <p className={`text-xs ${createStatus.ok ? "text-emerald-400" : "text-red-400"}`}>
+              {createStatus.msg}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={creating || !newUsername.trim() || !newPassword}
+            className="self-start px-5 py-2.5 rounded-xl bg-gradient-to-r from-brand-pink to-brand-purple text-white font-semibold text-sm hover:opacity-90 transition-all disabled:opacity-40 shadow-lg shadow-brand-pink/15"
+          >
+            {creating ? t.creating : t.createUser}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/lib/i18n/adminDict.ts
+++ b/lib/i18n/adminDict.ts
@@ -74,6 +74,7 @@ export const adminDict = {
     // Settings
     settings: "Settings",
     userManagement: "User Management",
+    accountManagement: "Account Management",
     accountSettings: "Account Settings",
     changeUsername: "Change Username",
     changePassword: "Change Password",
@@ -87,6 +88,28 @@ export const adminDict = {
     incorrectPassword: "Current password is incorrect.",
     usernameUpdated: "Username updated successfully.",
     passwordUpdated: "Password updated successfully.",
+
+    // User management
+    manageUsers: "Manage Users",
+    manageUsersDesc: "Create and manage admin and crew accounts.",
+    roleLabel: "Role",
+    adminRole: "Admin",
+    crewRole: "Crew",
+    createUser: "Create User",
+    creating: "Creating...",
+    userCreated: "User created successfully.",
+    failedToCreateUser: "Failed to create user.",
+    confirmDeleteUser: "Delete this user? This cannot be undone.",
+    userDeleted: "User deleted.",
+    failedToDeleteUser: "Failed to delete user.",
+    noUsers: "No users yet.",
+
+    // Admin auth modal (crew cancel)
+    adminAuthRequired: "Admin Authorization Required",
+    adminAuthDesc: "Cancellations require admin approval. Enter admin credentials to proceed.",
+    verifying: "Verifying...",
+    confirmCancel: "Confirm Cancel",
+    invalidAdminCredentials: "Invalid admin credentials.",
   },
   ja: {
     // Common
@@ -161,6 +184,7 @@ export const adminDict = {
     // Settings
     settings: "設定",
     userManagement: "ユーザー管理",
+    accountManagement: "アカウント管理",
     accountSettings: "アカウント設定",
     changeUsername: "ユーザー名を変更",
     changePassword: "パスワードを変更",
@@ -174,5 +198,27 @@ export const adminDict = {
     incorrectPassword: "現在のパスワードが正しくありません。",
     usernameUpdated: "ユーザー名を更新しました。",
     passwordUpdated: "パスワードを更新しました。",
+
+    // User management
+    manageUsers: "ユーザー管理",
+    manageUsersDesc: "管理者とクルーのアカウントを作成・管理します。",
+    roleLabel: "ロール",
+    adminRole: "管理者",
+    crewRole: "クルー",
+    createUser: "ユーザーを作成",
+    creating: "作成中...",
+    userCreated: "ユーザーを作成しました。",
+    failedToCreateUser: "ユーザーの作成に失敗しました。",
+    confirmDeleteUser: "このユーザーを削除しますか？この操作は取り消せません。",
+    userDeleted: "ユーザーを削除しました。",
+    failedToDeleteUser: "ユーザーの削除に失敗しました。",
+    noUsers: "ユーザーがいません。",
+
+    // Admin auth modal (crew cancel)
+    adminAuthRequired: "管理者認証が必要です",
+    adminAuthDesc: "キャンセルには管理者の承認が必要です。管理者の認証情報を入力してください。",
+    verifying: "確認中...",
+    confirmCancel: "キャンセルを確定",
+    invalidAdminCredentials: "管理者の認証情報が正しくありません。",
   },
 };

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -14,6 +14,9 @@ export interface Order {
   status: OrderStatus;
   note: string | null;
   total: number;
+  completed_by: string | null;
+  canceled_by: string | null;
+  authorized_by: string | null;
   created_at: string;
   updated_at: string;
   // Joined
@@ -64,6 +67,9 @@ interface OrderRow {
   status: OrderStatus;
   note: string | null;
   total: number;
+  completed_by: string | null;
+  canceled_by: string | null;
+  authorized_by: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Adds crew role with restricted access: order feed only; direct navigation to Table/Settings pages redirects to /admin
- Crew cancel requires admin credentials via an auth modal; cancellation proceeds automatically on approval
- Admins can create and delete crew/admin accounts from a new User Management section on the Settings page
- Settings page restructured into a two-column layout: Account Management (left) and User Management (right)
- Order status changes now record completed_by, canceled_by, and authorized_by for a full audit trail (requires ALTER TABLE migration)