### PR TITLE
Use completed_business_date for analytics and order history

### DIFF
--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -3,8 +3,9 @@ import { supabase } from "@/lib/supabase/client";
 import { verifyAdminCookie, getAdminTokenPayload } from "@/app/api/admin-auth/route";
 
 // Business day starts at 20:00 JST — orders from 20:00 day N to 19:59 day N+1
-// belong to day N's business_date. Formula matches the generated column:
-// (created_at AT TIME ZONE 'Asia/Tokyo' - INTERVAL '20 hours')::date
+// belong to day N. Formula matches the generated columns:
+// business_date:           (created_at AT TIME ZONE 'Asia/Tokyo' - INTERVAL '20 hours')::date
+// completed_business_date: (updated_at  AT TIME ZONE 'Asia/Tokyo' - INTERVAL '20 hours')::date
 function currentBusinessDate(): string {
   // +9h for JST, -20h for business day shift = net -11h from UTC
   const shifted = new Date(Date.now() - 11 * 60 * 60 * 1000);
@@ -34,7 +35,8 @@ interface RawOrder {
   status: string;
   total: number;
   created_at: string;
-  business_date: string;
+  updated_at: string;
+  completed_business_date: string;
   table_id: string;
   // Supabase returns joined relations as object or array depending on client inference
   table: { name: string } | { name: string }[] | null;
@@ -125,7 +127,7 @@ function computeAnalytics(
     for (let h = 20; h <= 28; h++) hourData[h] = { revenue: 0, losses: 0 };
 
     for (const order of orders) {
-      const jstHour = (new Date(order.created_at).getUTCHours() + 9) % 24;
+      const jstHour = (new Date(order.updated_at).getUTCHours() + 9) % 24;
       const bizH = jstHour >= 20 ? jstHour : jstHour + 24;
       if (bizH >= 20 && bizH <= 28) {
         if (order.status === "done") hourData[bizH].revenue += order.total || 0;
@@ -145,7 +147,7 @@ function computeAnalytics(
       dateData[new Date(ms).toISOString().split("T")[0]] = { revenue: 0, losses: 0 };
     }
     for (const order of orders) {
-      const d = order.business_date;
+      const d = order.completed_business_date;
       if (d && dateData[d] !== undefined) {
         if (order.status === "done") dateData[d].revenue += order.total || 0;
         else if (order.status === "cancelled") dateData[d].losses += order.total || 0;
@@ -279,10 +281,10 @@ export async function GET(request: NextRequest) {
   const { data: orders, error } = await supabase
     .from("orders")
     .select(
-      "id, status, total, created_at, business_date, table_id, table:tables(name), items:order_items(item_key, item_name_en, item_name_ja, price, quantity)"
+      "id, status, total, created_at, updated_at, completed_business_date, table_id, table:tables(name), items:order_items(item_key, item_name_en, item_name_ja, price, quantity)"
     )
-    .gte("business_date", startDate)
-    .lte("business_date", endDate);
+    .gte("completed_business_date", startDate)
+    .lte("completed_business_date", endDate);
 
   if (error) {
     console.error("[analytics] DB error:", error.message);
@@ -299,8 +301,8 @@ export async function GET(request: NextRequest) {
     const { data: priorOrders } = await supabase
       .from("orders")
       .select("status, total")
-      .gte("business_date", priorStart)
-      .lte("business_date", priorEnd);
+      .gte("completed_business_date", priorStart)
+      .lte("completed_business_date", priorEnd);
 
     if (priorOrders) {
       const priorDone = priorOrders.filter((o) => o.status === "done");

--- a/app/api/orders/route.ts
+++ b/app/api/orders/route.ts
@@ -97,8 +97,8 @@ export async function GET(request: NextRequest) {
       table:tables(id, name),
       items:order_items(*)
     `)
-    .eq("business_date", businessDate)
-    .order("created_at", { ascending: false });
+    .eq("completed_business_date", businessDate)
+    .order("updated_at", { ascending: false });
 
   if (tableId) query = query.eq("table_id", tableId);
   if (status) query = query.eq("status", status);

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -18,6 +18,7 @@ export interface Order {
   canceled_by: string | null;
   authorized_by: string | null;
   business_date?: string; // generated column: (created_at AT TIME ZONE 'Asia/Tokyo' - INTERVAL '20 hours')::date
+  completed_business_date?: string; // generated column: (updated_at AT TIME ZONE 'Asia/Tokyo' - INTERVAL '20 hours')::date
   created_at: string;
   updated_at: string;
   // Joined
@@ -71,7 +72,8 @@ interface OrderRow {
   completed_by: string | null;
   canceled_by: string | null;
   authorized_by: string | null;
-  business_date: string; // generated column
+  business_date: string; // generated column: (created_at AT TIME ZONE 'Asia/Tokyo' - INTERVAL '20 hours')::date
+  completed_business_date: string; // generated column: (updated_at AT TIME ZONE 'Asia/Tokyo' - INTERVAL '20 hours')::date
   created_at: string;
   updated_at: string;
 }
@@ -87,8 +89,8 @@ export interface Database {
       };
       orders: {
         Row: OrderRow;
-        Insert: Omit<OrderRow, "id" | "created_at" | "updated_at">;
-        Update: Partial<Omit<OrderRow, "id" | "created_at" | "updated_at">>;
+        Insert: Omit<OrderRow, "id" | "created_at" | "updated_at" | "business_date" | "completed_business_date">;
+        Update: Partial<Omit<OrderRow, "id" | "created_at" | "updated_at" | "business_date" | "completed_business_date">>;
       };
       order_items: {
         Row: OrderItem;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -17,14 +17,25 @@ create table if not exists tables (
 -- A device can submit multiple orders during a 12h session.
 
 create table if not exists orders (
-  id         uuid primary key default gen_random_uuid(),
-  table_id   uuid not null references tables(id) on delete cascade,
-  session_id text not null,         -- random UUID per device, stored in localStorage
-  status     text not null default 'pending' check (status in ('pending', 'done')),
-  note       text,                  -- optional customer note
-  total      integer not null default 0, -- total in yen (sum of items)
-  created_at timestamptz not null default now(),
-  updated_at timestamptz not null default now()
+  id                      uuid primary key default gen_random_uuid(),
+  table_id                uuid not null references tables(id) on delete cascade,
+  session_id              text not null,         -- random UUID per device, stored in localStorage
+  status                  text not null default 'pending' check (status in ('pending', 'done', 'cancelled')),
+  note                    text,                  -- optional customer note
+  total                   integer not null default 0, -- total in yen (sum of items)
+  completed_by            text,                  -- username of staff who marked done
+  canceled_by             text,                  -- username of staff who cancelled
+  authorized_by           text,                  -- username of staff who authorized
+  created_at              timestamptz not null default now(),
+  updated_at              timestamptz not null default now(),
+  -- Business day the order was placed (20:00 JST boundary)
+  business_date           date generated always as (
+                            (created_at at time zone 'Asia/Tokyo' - interval '20 hours')::date
+                          ) stored,
+  -- Business day the order was resolved (done/cancelled) — used for analytics and history
+  completed_business_date date generated always as (
+                            (updated_at at time zone 'Asia/Tokyo' - interval '20 hours')::date
+                          ) stored
 );
 
 -- ─── Order Items ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Analytics and order history now filter by `completed_business_date` (based on `updated_at`) instead of `business_date` (based on `created_at`)
- Revenue/losses are attributed to the business day an order was resolved, not when it was placed
- Today's trend chart now buckets revenue by the hour the order was completed (`updated_at`), not placed
- Fixes `business_date` DB column which had an incorrect `-6h` offset instead of `-20h`
- Updates `schema.sql` and TypeScript types to reflect the actual DB schema